### PR TITLE
Issue #15 pass query params to page requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@d-i-t-a/reader",
-  "version": "2.4.10",
+  "name": "@savaslabs/reader",
+  "version": "2.4.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@d-i-t-a/reader",
-      "version": "2.4.10",
+      "name": "@savaslabs/reader",
+      "version": "2.4.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@savaslabs/reader",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@savaslabs/reader",
-      "version": "2.4.13",
+      "version": "2.4.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@savaslabs/reader",
-  "version": "2.4.12",
+  "version": "2.4.13",
   "description": "A viewer application for EPUB files forked from @d-i-t-a/reader.",
   "repository": "https://github.com/savaslabs/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@savaslabs/reader",
-  "version": "2.4.13",
+  "version": "2.4.14",
   "description": "A viewer application for EPUB files forked from @d-i-t-a/reader.",
   "repository": "https://github.com/savaslabs/R2D2BC",
   "license": "Apache-2.0",

--- a/src/model/Publication.ts
+++ b/src/model/Publication.ts
@@ -43,10 +43,29 @@ export class Publication extends R2Publication {
     url: URL,
     requestConfig?: RequestConfig
   ): Promise<Publication> {
-    const response = await fetch(url.href, requestConfig);
+    // Extract query parameters from manifest URL
+    const manifestParams = new URLSearchParams(url.search);
+
+    // Create a new requestConfig that includes the manifest query parameters
+    const updatedRequestConfig: RequestConfig = {
+      ...requestConfig,
+      headers: {
+        ...requestConfig?.headers,
+      },
+    };
+
+    // Add query parameters to the URL if they don't already exist
+    const manifestUrl = new URL(url.href);
+    manifestParams.forEach((value, key) => {
+      if (!manifestUrl.searchParams.has(key)) {
+        manifestUrl.searchParams.append(key, value);
+      }
+    });
+
+    const response = await fetch(manifestUrl.href, updatedRequestConfig);
     const manifestJSON = await response.json();
     let publication = TaJsonDeserialize<Publication>(manifestJSON, Publication);
-    publication.manifestUrl = url;
+    publication.manifestUrl = manifestUrl;
     return publication;
   }
 
@@ -165,7 +184,18 @@ export class Publication extends R2Publication {
   }
 
   public getAbsoluteHref(href: string): string {
-    return new URL(href, this.manifestUrl.href).href;
+    // Create a new URL with the base manifest URL
+    const absoluteUrl = new URL(href, this.manifestUrl.href);
+
+    // Copy query parameters from manifest URL to the resource URL
+    const manifestParams = new URLSearchParams(this.manifestUrl.search);
+    manifestParams.forEach((value, key) => {
+      if (!absoluteUrl.searchParams.has(key)) {
+        absoluteUrl.searchParams.append(key, value);
+      }
+    });
+
+    return absoluteUrl.href;
   }
 
   public getRelativeHref(href: string): string {


### PR DESCRIPTION
This closes #15 

To test:
- [x] Checkout this branch
- [x] Edit `viewer/index_minimal.html` line 85 to pass sample query params to the manfest.json file: `url: new URL(urlParams['url'] + '?token=abc123&session=xyz789'),`
- [x] `npm run build && npm run examples`
- [x] Open an epub with the minimal viewer
- [x] Inspect, open the network tab, and search `token`
- [x] Reload the page and navigate forwards and backwards
- [x] Confirm query params are passed through to the page requests
<img width="1012" alt="Screenshot 2025-04-29 at 10 11 44 AM" src="https://github.com/user-attachments/assets/59d3a0ae-88b4-414f-aabb-404698c8660b" />