### PR TITLE
Feature/15 pass params to assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@savaslabs/reader",
-  "version": "2.4.14",
+  "version": "2.4.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@savaslabs/reader",
-      "version": "2.4.14",
+      "version": "2.4.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@savaslabs/reader",
-  "version": "2.4.14",
+  "version": "2.4.15",
   "description": "A viewer application for EPUB files forked from @d-i-t-a/reader.",
   "repository": "https://github.com/savaslabs/R2D2BC",
   "license": "Apache-2.0",

--- a/src/modules/mediaoverlays/MediaOverlayModule.ts
+++ b/src/modules/mediaoverlays/MediaOverlayModule.ts
@@ -505,11 +505,14 @@ export class MediaOverlayModule implements ReaderModule {
       moTextAudioPair.Audio,
       this.publication.manifestUrl
     );
+    const manifestUrl = new URL(this.publication.manifestUrl);
+    manifestUrl.searchParams.forEach((value, key) => {
+      urlObjFull.searchParams.set(key, value);
+    });
     const urlFull = urlObjFull.toString();
 
     const urlObjNoQuery = new URL(urlFull);
     urlObjNoQuery.hash = "";
-    urlObjNoQuery.search = "";
     const urlNoQuery = urlObjNoQuery.toString();
 
     const hasBegin = typeof begin !== "undefined";

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -98,6 +98,7 @@ import {
   ConsumptionModuleConfig,
 } from "../modules/consumption/ConsumptionModule";
 import KeyDownEvent = JQuery.KeyDownEvent;
+import { createResourceInterceptorScript } from "../utils/ResourceInterceptor";
 
 export type GetContent = (href: string) => Promise<string>;
 export type GetContentBytesLength = (
@@ -1671,6 +1672,12 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           head.firstChild
         );
       }
+
+      // Inject fetch override script
+      const manifestUrl = this.publication.manifestUrl || "";
+      const resourceInterceptorScript =
+        createResourceInterceptorScript(manifestUrl);
+      head.appendChild(resourceInterceptorScript);
 
       this.injectables?.forEach((injectable) => {
         if (injectable.type === "style") {

--- a/src/utils/ResourceInterceptor.ts
+++ b/src/utils/ResourceInterceptor.ts
@@ -1,0 +1,125 @@
+/**
+ * Utility for adding query parameters to resource URLs in iframes
+ */
+
+/**
+ * Creates a script element that adds query parameters to resource URLs
+ */
+export function createResourceInterceptorScript(
+  manifestUrl: string | URL
+): HTMLScriptElement {
+  const scriptElement = document.createElement("script");
+  scriptElement.type = "text/javascript";
+  scriptElement.textContent = generateResourceInterceptorCode(manifestUrl);
+  return scriptElement;
+}
+
+/**
+ * Generates code to add query parameters to resource URLs
+ */
+export function generateResourceInterceptorCode(
+  manifestUrl: string | URL
+): string {
+  // Extract query string from the manifest URL
+  let queryString = "";
+  try {
+    if (manifestUrl) {
+      const url =
+        typeof manifestUrl === "string" ? new URL(manifestUrl) : manifestUrl;
+      queryString = url.search.startsWith("?")
+        ? url.search.substring(1)
+        : url.search;
+    }
+  } catch (e) {
+    console.error("Error parsing manifestUrl:", e);
+  }
+
+  return `
+    // Only process if we have query parameters
+    const queryParams = ${JSON.stringify(queryString)};
+    if (!queryParams) {
+      // Using void(0) instead of return which is illegal at global scope
+      void(0);
+    } else {
+      // Add parameters to a URL
+      function addParams(url) {
+        if (!url || typeof url !== 'string' || url.startsWith('data:') || 
+            url.startsWith('blob:') || url.startsWith('#') || 
+            url.startsWith('javascript:')) return url;
+        
+        const separator = url.includes('?') ? '&' : '?';
+        return url + separator + queryParams;
+      }
+
+      // Update an element's attribute if needed
+      function updateAttribute(element, attr) {
+        if (!element.hasAttribute(attr)) return;
+        
+        const value = element.getAttribute(attr);
+        if (!value) return;
+        
+        // Special handling for srcset
+        if (attr === 'srcset') {
+          const newValue = value.split(',')
+            .map(set => {
+              const [url, ...rest] = set.trim().split(/\\s+/);
+              return addParams(url) + (rest.length ? ' ' + rest.join(' ') : '');
+            })
+            .join(', ');
+          if (newValue !== value) element.setAttribute(attr, newValue);
+          return;
+        }
+        
+        // Regular attribute handling
+        const newValue = addParams(value);
+        if (newValue !== value) element.setAttribute(attr, newValue);
+      }
+      
+      // Process all resources in the document
+      function processResources() {
+        // Process all elements with resource attributes
+        ['src', 'href', 'data'].forEach(attr => {
+          document.querySelectorAll('[' + attr + ']').forEach(el => {
+            // Special handling for scripts to ensure they reload
+            if (attr === 'src' && el.tagName === 'SCRIPT') {
+              const src = el.getAttribute('src');
+              const newSrc = addParams(src);
+              if (newSrc !== src) {
+                const newScript = document.createElement('script');
+                Array.from(el.attributes).forEach(a => {
+                  newScript.setAttribute(a.name === 'src' ? a.name : a.name, 
+                                        a.name === 'src' ? newSrc : a.value);
+                });
+                el.parentNode?.replaceChild(newScript, el);
+              }
+            } else {
+              updateAttribute(el, attr);
+            }
+          });
+        });
+        
+        // Handle srcset attribute
+        document.querySelectorAll('[srcset]').forEach(el => {
+          updateAttribute(el, 'srcset');
+        });
+
+        // Handle inline styles with background images
+        document.querySelectorAll('[style*="url("]').forEach(el => {
+          const style = el.getAttribute('style');
+          if (!style) return;
+          
+          const newStyle = style.replace(/url\\(['"]?([^'"\\)]+)['"]?\\)/g, 
+                                      (_, url) => 'url("' + addParams(url) + '")');
+          if (newStyle !== style) el.setAttribute('style', newStyle);
+        });
+      }
+
+      // Run when DOM is loaded
+      if (document.readyState !== 'loading') {
+        processResources();
+      } else {
+        document.addEventListener('DOMContentLoaded', processResources);
+      }
+    }
+  `;
+}


### PR DESCRIPTION
## Purpose of This PR
This closes #15 again - We need to pass the signed url query params through to all resources, not just the top-level page.

## Notes

- [x] I have run `npx tsc` without errors.

## Design Reference

## To Test
- [x] On `develop`, 
  - [x] Edit `index_dita.html` with ` url: new URL(urlParams["url"] + "?token=abc"),` on line 990
  - [x] `npm run build && npm run examples`
  - [x] Open any book, and open the network tab, then reload the page
  - [x] Filter requests by `token=abc`
  - [x] You'll see `page.xhtml?token=abc` and `manifest.json?token=abc`, but none of the images or other assets will have that token appended. That won't work, BOO
- [x] Checkout this branch
  - [x] Edit `index_dita.html` with ` url: new URL(urlParams["url"] + "?token=abc"),` on line 990
  - [x] `npm run build && npm run examples`
  - [x] Open any book, and open the network tab, then reload the page
  - [x] Filter requests by `token=abc` - you'll see that everything now gets the query params
  - [ ] Hit the play button in the top right
![Screenshot 2025-05-12 at 3 46 00 PM](https://github.com/user-attachments/assets/c8bd160e-db6c-41fc-8cb1-065f3a47b24c)
  - [ ] Even the mp3 file gets the query params!
