### PR TITLE
Issue #15: Append query params into contentdoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@savaslabs/reader",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@savaslabs/reader",
-      "version": "2.4.15",
+      "version": "2.4.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@savaslabs/reader",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@savaslabs/reader",
-      "version": "2.4.16",
+      "version": "2.4.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@savaslabs/reader",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "description": "A viewer application for EPUB files forked from @d-i-t-a/reader.",
   "repository": "https://github.com/savaslabs/R2D2BC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@savaslabs/reader",
-  "version": "2.4.16",
+  "version": "2.4.17",
   "description": "A viewer application for EPUB files forked from @d-i-t-a/reader.",
   "repository": "https://github.com/savaslabs/R2D2BC",
   "license": "Apache-2.0",

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -98,7 +98,7 @@ import {
   ConsumptionModuleConfig,
 } from "../modules/consumption/ConsumptionModule";
 import KeyDownEvent = JQuery.KeyDownEvent;
-import { createResourceInterceptorScript } from "../utils/ResourceInterceptor";
+import { addQueryParamsToResources } from "../utils/ResourceInterceptor";
 
 export type GetContent = (href: string) => Promise<string>;
 export type GetContentBytesLength = (
@@ -1673,12 +1673,6 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         );
       }
 
-      // Inject fetch override script
-      const manifestUrl = this.publication.manifestUrl || "";
-      const resourceInterceptorScript =
-        createResourceInterceptorScript(manifestUrl);
-      head.appendChild(resourceInterceptorScript);
-
       this.injectables?.forEach((injectable) => {
         if (injectable.type === "style") {
           if (injectable.fontFamily) {
@@ -1766,7 +1760,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
 
     this.currentSpreadLinks = {};
 
-    function writeIframeDoc(content: string, href: string) {
+    const writeIframeDoc = (content: string, href: string) => {
       const parser = new DOMParser();
       const doc = parser.parseFromString(content, "application/xhtml+xml");
       if (doc.head) {
@@ -1778,6 +1772,10 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           );
         }
       }
+
+      // Process and add query parameters to resources
+      addQueryParamsToResources(doc, this.publication.manifestUrl);
+
       const newHTML = doc.documentElement.outerHTML;
       const iframeDoc = self.iframes[0].contentDocument;
       if (iframeDoc) {
@@ -1785,9 +1783,9 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         iframeDoc.write(newHTML);
         iframeDoc.close();
       }
-    }
+    };
 
-    function writeIframe2Doc(content: string, href: string) {
+    const writeIframe2Doc = (content: string, href: string) => {
       const parser = new DOMParser();
       const doc = parser.parseFromString(content, "application/xhtml+xml");
       if (doc.head) {
@@ -1799,6 +1797,10 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
           );
         }
       }
+
+      // Process and add query parameters to resources
+      addQueryParamsToResources(doc, this.publication.manifestUrl);
+
       const newHTML = doc.documentElement.outerHTML;
       const iframeDoc = self.iframes[1].contentDocument;
       if (iframeDoc) {
@@ -1806,7 +1808,7 @@ export class IFrameNavigator extends EventEmitter implements Navigator {
         iframeDoc.write(newHTML);
         iframeDoc.close();
       }
-    }
+    };
 
     const link = new URL(this.currentChapterLink.href);
     const isSameOrigin =

--- a/src/utils/ResourceInterceptor.ts
+++ b/src/utils/ResourceInterceptor.ts
@@ -1,125 +1,121 @@
 /**
- * Utility for adding query parameters to resource URLs in iframes
+ * ResourceInterceptor
+ *
+ * A utility module that handles the interception and modification of resource URLs
+ * in HTML documents. It adds query parameters from a manifest URL to all resource
+ * URLs found in the document, including:
+ * - Elements with src, href, and data attributes
+ * - Images with srcset attributes
+ * - Inline styles with background-image URLs
+ * - URLs in style elements
+ *
+ * This module is used to ensure all resources loaded by an iframe maintain the
+ * query parameters from the original manifest URL.
  */
 
 /**
- * Creates a script element that adds query parameters to resource URLs
+ * Adds query parameters from a manifest URL to all resource URLs in a document.
+ *
+ * This function processes the document and modifies all resource URLs to include
+ * the query parameters from the manifest URL. It handles various types of URLs:
+ * - Absolute URLs
+ * - Relative URLs
+ * - URLs in srcset attributes
+ * - URLs in inline styles
+ * - URLs in style elements
+ *
+ * Special URL schemes (data:, blob:, #, javascript:) are preserved without modification.
+ *
+ * @param doc - The HTML document to process. Must be a valid Document object.
+ * @param manifestUrl - The manifest URL containing query parameters to add. Must be a valid URL object.
+ * @returns void
  */
-export function createResourceInterceptorScript(
-  manifestUrl: string | URL
-): HTMLScriptElement {
-  const scriptElement = document.createElement("script");
-  scriptElement.type = "text/javascript";
-  scriptElement.textContent = generateResourceInterceptorCode(manifestUrl);
-  return scriptElement;
-}
+export const addQueryParamsToResources = (doc: Document, manifestUrl: URL) => {
+  // Validate input parameters
+  if (!doc || !manifestUrl) {
+    return;
+  }
 
-/**
- * Generates code to add query parameters to resource URLs
- */
-export function generateResourceInterceptorCode(
-  manifestUrl: string | URL
-): string {
-  // Extract query string from the manifest URL
+  // Extract query parameters from manifest URL if available
   let queryString = "";
-  try {
-    if (manifestUrl) {
-      const url =
-        typeof manifestUrl === "string" ? new URL(manifestUrl) : manifestUrl;
+  if (manifestUrl) {
+    try {
+      const url = new URL(manifestUrl);
       queryString = url.search.startsWith("?")
         ? url.search.substring(1)
         : url.search;
+    } catch (e) {
+      console.error("Error parsing manifestUrl:", e);
     }
-  } catch (e) {
-    console.error("Error parsing manifestUrl:", e);
   }
 
-  return `
-    // Only process if we have query parameters
-    const queryParams = ${JSON.stringify(queryString)};
-    if (!queryParams) {
-      // Using void(0) instead of return which is illegal at global scope
-      void(0);
-    } else {
-      // Add parameters to a URL
-      function addParams(url) {
-        if (!url || typeof url !== 'string' || url.startsWith('data:') || 
-            url.startsWith('blob:') || url.startsWith('#') || 
-            url.startsWith('javascript:')) return url;
-        
-        const separator = url.includes('?') ? '&' : '?';
-        return url + separator + queryParams;
+  // Add query parameters to resource URLs directly if query string exists
+  if (queryString) {
+    // Helper to add params to a URL while preserving special URL schemes
+    const addParams = (url: string): string => {
+      if (
+        !url ||
+        url.startsWith("data:") ||
+        url.startsWith("blob:") ||
+        url.startsWith("#") ||
+        // eslint-disable-next-line no-script-url
+        url.startsWith("javascript:")
+      ) {
+        return url;
       }
 
-      // Update an element's attribute if needed
-      function updateAttribute(element, attr) {
-        if (!element.hasAttribute(attr)) return;
-        
-        const value = element.getAttribute(attr);
-        if (!value) return;
-        
-        // Special handling for srcset
-        if (attr === 'srcset') {
-          const newValue = value.split(',')
-            .map(set => {
-              const [url, ...rest] = set.trim().split(/\\s+/);
-              return addParams(url) + (rest.length ? ' ' + rest.join(' ') : '');
-            })
-            .join(', ');
-          if (newValue !== value) element.setAttribute(attr, newValue);
-          return;
+      const separator = url.includes("?") ? "&" : "?";
+      return url + separator + queryString;
+    };
+
+    // Process elements with resource attributes (src, href, data)
+    ["src", "href", "data"].forEach((attr) => {
+      doc.querySelectorAll(`[${attr}]`).forEach((el) => {
+        const value = el.getAttribute(attr);
+        if (value) {
+          el.setAttribute(attr, addParams(value));
         }
-        
-        // Regular attribute handling
-        const newValue = addParams(value);
-        if (newValue !== value) element.setAttribute(attr, newValue);
-      }
-      
-      // Process all resources in the document
-      function processResources() {
-        // Process all elements with resource attributes
-        ['src', 'href', 'data'].forEach(attr => {
-          document.querySelectorAll('[' + attr + ']').forEach(el => {
-            // Special handling for scripts to ensure they reload
-            if (attr === 'src' && el.tagName === 'SCRIPT') {
-              const src = el.getAttribute('src');
-              const newSrc = addParams(src);
-              if (newSrc !== src) {
-                const newScript = document.createElement('script');
-                Array.from(el.attributes).forEach(a => {
-                  newScript.setAttribute(a.name === 'src' ? a.name : a.name, 
-                                        a.name === 'src' ? newSrc : a.value);
-                });
-                el.parentNode?.replaceChild(newScript, el);
-              }
-            } else {
-              updateAttribute(el, attr);
+      });
+    });
+
+    // Process srcset attributes for responsive images
+    doc.querySelectorAll("[srcset]").forEach((el) => {
+      const srcset = el.getAttribute("srcset");
+      if (srcset) {
+        const newValue = srcset
+          .split(",")
+          .map((set) => {
+            const parts = set.trim().split(/\s+/);
+            if (parts.length > 0) {
+              parts[0] = addParams(parts[0]);
             }
-          });
-        });
-        
-        // Handle srcset attribute
-        document.querySelectorAll('[srcset]').forEach(el => {
-          updateAttribute(el, 'srcset');
-        });
-
-        // Handle inline styles with background images
-        document.querySelectorAll('[style*="url("]').forEach(el => {
-          const style = el.getAttribute('style');
-          if (!style) return;
-          
-          const newStyle = style.replace(/url\\(['"]?([^'"\\)]+)['"]?\\)/g, 
-                                      (_, url) => 'url("' + addParams(url) + '")');
-          if (newStyle !== style) el.setAttribute('style', newStyle);
-        });
+            return parts.join(" ");
+          })
+          .join(", ");
+        el.setAttribute("srcset", newValue);
       }
+    });
 
-      // Run when DOM is loaded
-      if (document.readyState !== 'loading') {
-        processResources();
-      } else {
-        document.addEventListener('DOMContentLoaded', processResources);
+    // Process inline styles containing background-image URLs
+    doc.querySelectorAll("[style*='url(']").forEach((el) => {
+      const style = el.getAttribute("style");
+      if (style) {
+        const newStyle = style.replace(
+          /url\(['"]?([^'"\)]+)['"]?\)/g,
+          (match, url) => `url("${addParams(url)}")`
+        );
+        el.setAttribute("style", newStyle);
       }
-    }
-  `;
-}
+    });
+
+    // Process URLs in style elements
+    doc.querySelectorAll("style").forEach((styleEl) => {
+      if (styleEl.textContent) {
+        styleEl.textContent = styleEl.textContent.replace(
+          /url\(['"]?([^'"\)]+)['"]?\)/g,
+          (match, url) => `url("${addParams(url)}")`
+        );
+      }
+    });
+  }
+};

--- a/src/utils/ResourceInterceptor.ts
+++ b/src/utils/ResourceInterceptor.ts
@@ -2,22 +2,22 @@
  * ResourceInterceptor
  *
  * A utility module that handles the interception and modification of resource URLs
- * in HTML documents. It adds query parameters from a manifest URL to all resource
- * URLs found in the document, including:
+ * in HTML documents. It adds CloudFront signed URL parameters from a manifest URL
+ * to all resource URLs found in the document, including:
  * - Elements with src, href, and data attributes
  * - Images with srcset attributes
  * - Inline styles with background-image URLs
  * - URLs in style elements
  *
  * This module is used to ensure all resources loaded by an iframe maintain the
- * query parameters from the original manifest URL.
+ * CloudFront signed URL parameters from the original manifest URL.
  */
 
 /**
- * Adds query parameters from a manifest URL to all resource URLs in a document.
+ * Adds CloudFront signed URL parameters from a manifest URL to all resource URLs in a document.
  *
  * This function processes the document and modifies all resource URLs to include
- * the query parameters from the manifest URL. It handles various types of URLs:
+ * the CloudFront signed URL parameters from the manifest URL. It handles various types of URLs:
  * - Absolute URLs
  * - Relative URLs
  * - URLs in srcset attributes
@@ -25,9 +25,11 @@
  * - URLs in style elements
  *
  * Special URL schemes (data:, blob:, #, javascript:) are preserved without modification.
+ * Existing query parameters that don't conflict with CloudFront parameters are preserved.
+ * Relative URLs remain relative after parameter addition.
  *
  * @param doc - The HTML document to process. Must be a valid Document object.
- * @param manifestUrl - The manifest URL containing query parameters to add. Must be a valid URL object.
+ * @param manifestUrl - The manifest URL containing CloudFront signed URL parameters. Must be a valid URL object.
  * @returns void
  */
 export const addQueryParamsToResources = (doc: Document, manifestUrl: URL) => {
@@ -36,22 +38,34 @@ export const addQueryParamsToResources = (doc: Document, manifestUrl: URL) => {
     return;
   }
 
-  // Extract query parameters from manifest URL if available
-  let queryString = "";
+  // Extract CloudFront signed URL parameters from manifest URL if available
+  let cloudfrontParams = new URLSearchParams();
   if (manifestUrl) {
     try {
       const url = new URL(manifestUrl);
-      queryString = url.search.startsWith("?")
-        ? url.search.substring(1)
-        : url.search;
+      const allParams = new URLSearchParams(url.search);
+
+      // Only keep CloudFront signed URL parameters
+      const cloudfrontParamKeys = [
+        "Expires",
+        "Policy",
+        "Signature",
+        "Key-Pair-Id",
+      ];
+      cloudfrontParamKeys.forEach((key) => {
+        const value = allParams.get(key);
+        if (value) {
+          cloudfrontParams.set(key, value);
+        }
+      });
     } catch (e) {
       console.error("Error parsing manifestUrl:", e);
     }
   }
 
-  // Add query parameters to resource URLs directly if query string exists
-  if (queryString) {
-    // Helper to add params to a URL while preserving special URL schemes
+  // Add CloudFront parameters to resource URLs directly if they exist
+  if (cloudfrontParams.toString()) {
+    // Helper to add params to a URL while preserving special URL schemes and non-conflicting params
     const addParams = (url: string): string => {
       if (
         !url ||
@@ -64,8 +78,42 @@ export const addQueryParamsToResources = (doc: Document, manifestUrl: URL) => {
         return url;
       }
 
-      const separator = url.includes("?") ? "&" : "?";
-      return url + separator + queryString;
+      try {
+        // Check if URL is relative
+        const isRelative =
+          !url.startsWith("http://") && !url.startsWith("https://");
+
+        // For relative URLs, we need to handle the path and query separately
+        if (isRelative) {
+          const [path, existingQuery] = url.split("?");
+          const existingParams = new URLSearchParams(existingQuery || "");
+
+          // Add CloudFront params, preserving non-conflicting existing params
+          cloudfrontParams.forEach((value, key) => {
+            existingParams.set(key, value);
+          });
+
+          // Reconstruct URL with combined params
+          const queryString = existingParams.toString();
+          return queryString ? `${path}?${queryString}` : path;
+        }
+
+        // For absolute URLs, use URL object for proper parsing
+        const resourceUrl = new URL(url);
+        const existingParams = new URLSearchParams(resourceUrl.search);
+
+        // Add CloudFront params, preserving non-conflicting existing params
+        cloudfrontParams.forEach((value, key) => {
+          existingParams.set(key, value);
+        });
+
+        // Reconstruct URL with combined params
+        resourceUrl.search = existingParams.toString();
+        return resourceUrl.toString();
+      } catch (e) {
+        console.warn(`Invalid URL "${url}":`, e);
+        return url;
+      }
     };
 
     // Process elements with resource attributes (src, href, data)


### PR DESCRIPTION
## Purpose of This PR
This can be tested in https://github.com/savaslabs/rif-skybrary-hybrid/pull/339

## Notes

This PR ensures assets loaded through the content document of the iframe include [Cloudfront Signed URL](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-signed-urls.html) params set on the manifest.json file -- this allows all premium book assets to be loaded via signed urls, except fonts loaded through `@import` on external style sheets.

## To Test
- [x] Ozle: This could be tested entirely on https://github.com/savaslabs/rif-skybrary-hybrid/pull/339

But if you want to test here:
- [ ] Instructions assume you already have the repo set up locally and have local epubs.
- [ ] Checkout this branch
- [ ] Edit `viewer/index_minimal.html` line 85 to pass sample query params to the manifest.json file: `url: new URL(urlParams['url'] + '?Policy=abc123&Key-Pair-Id=xyz789&Token=abc'),`
- [ ] `npm run build && npm run examples`
- [ ] Open an epub with the minimal viewer
- [ ] Inspect, open the network tab, and search `token`
- [ ] Reload the page and navigate forwards and backwards
- [ ] Confirm `Policy` and `Key-Pair-Id` params are passed to asset requests, but `Token` is not.